### PR TITLE
add tests and fix threading bugs

### DIFF
--- a/src/entry.go
+++ b/src/entry.go
@@ -27,6 +27,7 @@ type EntryNode struct {
 type IEntryLinkedList interface {
 	len() int
 	begin() *EntryNode
+	end() *EntryNode
 	prepend(*Entry)
 	append(*Entry)
 	appendEntries([]*Entry)
@@ -127,6 +128,14 @@ func (p *EntryLinkedList) begin() *EntryNode {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+func (p *EntryLinkedList) end() *EntryNode {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	return p.tail
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 func (p *EntryLinkedList) len() int {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
@@ -180,7 +189,7 @@ func (p *EntryHashTable) emplace(e *Entry) {
 
 	key := p.hash(e.name)
 	if table, ok := p.storage[key]; ok {
-		table = append(table, e)
+		p.storage[key] = append(table, e)
 		return
 	}
 	p.storage[key] = make([]*Entry, 0, 1)

--- a/src/entry_manager_test.go
+++ b/src/entry_manager_test.go
@@ -1,0 +1,204 @@
+package dsearch
+
+import (
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+
+func BenchmarkLoadEntries(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m := NewEntryManager(nil)
+		m.LoadEntries(
+			func(c chan *Entry) { loadApplications(c) },
+			func(c chan *Entry) { loadFiles(c, true) },
+		)()
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+func (p *EntryNode) extract() []string {
+	var result []string
+	for i := p; i != nil; i = i.next {
+		result = append(result, i.value())
+	}
+	return result
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+func TestFilterEntry(t *testing.T) {
+	var expected, result []string
+	m := NewEntryManager(nil)
+	loadDummies := func(entryChan chan *Entry) {
+		for i := uint64(0); i < 1000000; i++ {
+			entryChan <- &Entry{
+				name: strconv.FormatUint(i, 10) + "_"}
+		}
+	}
+	m.LoadEntries(loadDummies)()
+	filterEntry := func(s string) {
+		if msg, ok := m.FilterEntry(s)().(FilteredMsg); ok {
+			result = msg.list.begin().extract()
+		} else {
+			t.Errorf(`Expected FilteredMsg got %v`, msg)
+		}
+	}
+
+	filterEntry("42069_")
+	expected = []string{
+		"42069_",
+		"142069_",
+		"242069_",
+		"342069_",
+		"442069_",
+		"542069_",
+		"642069_",
+		"742069_",
+		"842069_",
+		"942069_"}
+	if !slices.Equal(expected, result) {
+		t.Errorf(`Expected %v got %v`, expected, result)
+	}
+
+	filterEntry("999999_")
+	expected = []string{"999999_"}
+	if !slices.Equal(expected, result) {
+		t.Errorf(`Expected %v got %v`, expected, result)
+	}
+
+	filterEntry("xxxxxx_")
+	expected = []string{}
+	if !slices.Equal(expected, result) {
+		t.Errorf(`Expected %v got %v`, expected, result)
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+func TestFilterEntryBeforeDataReadyCase1(t *testing.T) {
+	var expected, result []string
+	var wg, fin sync.WaitGroup
+	m := NewEntryManager(nil)
+	loadDummies := func(entryChan chan *Entry) {
+		for i := uint64(0); i < 100000; i++ {
+			entryChan <- &Entry{
+				name: strconv.FormatUint(i, 10) + "_"}
+			if i == 42690 {
+				wg.Done()
+			}
+			if i == 96969 {
+				t.Logf(`There is 96969`)
+			}
+		}
+		fin.Done()
+	}
+	fin.Add(1)
+	wg.Add(1)
+	go m.LoadEntries(loadDummies)()
+	filterEntry := func(s string) {
+		if msg, ok := m.FilterEntry(s)().(FilteredMsg); ok {
+			result = msg.list.begin().extract()
+		} else {
+			t.Errorf(`Expected FilteredMsg got %v`, msg)
+		}
+	}
+
+	wg.Wait()
+	filterEntry("69420_")
+	expected = []string{"69420_"}
+	if !slices.Equal(expected, result) {
+		t.Errorf(`Expected %v got %v`, expected, result)
+	}
+	fin.Wait()
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+func TestFilterEntryBeforeDataReadyCase2(t *testing.T) {
+	var expected, result []string
+	var wg, fin sync.WaitGroup
+	m := NewEntryManager(nil)
+	loadDummies := func(entryChan chan *Entry) {
+		for i := uint64(0); i < 100000; i++ {
+			entryChan <- &Entry{
+				name: strconv.FormatUint(i, 10) + "_"}
+			if i == 69420 {
+				wg.Done()
+			}
+		}
+		fin.Done()
+	}
+	fin.Add(1)
+	wg.Add(1)
+	go m.LoadEntries(loadDummies)()
+	filterEntry := func(s string) {
+		if msg, ok := m.FilterEntry(s)().(FilteredMsg); ok {
+			result = msg.list.begin().extract()
+		} else {
+			t.Errorf(`Expected FilteredMsg got %v`, msg)
+		}
+	}
+
+	wg.Wait()
+	filterEntry("42069_")
+	expected = []string{"42069_"}
+	if !slices.Equal(expected, result) {
+		t.Errorf(`Expected %v got %v`, expected, result)
+	}
+	fin.Wait()
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+func TestFilterEntryBeforeDataReadyCase3(t *testing.T) {
+	var expected, result []string
+	var wg, fin sync.WaitGroup
+	m := NewEntryManager(nil)
+	loadDummies := func(entryChan chan *Entry) {
+		for i := uint64(0); i < 100000; i++ {
+			entryChan <- &Entry{
+				name: strconv.FormatUint(i, 10) + "_"}
+			if i == 46969 {
+				wg.Done()
+			}
+		}
+		t.Logf(`Finished to load dummies`)
+		fin.Done()
+	}
+	fin.Add(1)
+	wg.Add(1)
+	go m.LoadEntries(loadDummies)()
+	filterEntry := func(s string) {
+		if msg, ok := m.FilterEntry(s)().(FilteredMsg); ok {
+			result = msg.list.begin().extract()
+		} else {
+			t.Errorf(`Expected FilteredMsg got %v`, msg)
+		}
+	}
+
+	wg.Wait()
+	filterEntry("6969_")
+	expected = []string{
+		"6969_",
+		"16969_",
+		"26969_",
+		"36969_",
+		"46969_",
+		"56969_",
+		"66969_",
+		"76969_",
+		"86969_",
+		"96969_",
+	}
+	if !slices.Equal(expected, result) {
+		t.Errorf(`Expected %v got %v`, expected, result)
+	}
+	fin.Wait()
+}
+
+///////////////////////////////////////////////////////////////////////////////

--- a/src/entry_test.go
+++ b/src/entry_test.go
@@ -1,0 +1,100 @@
+package dsearch
+
+import (
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestEntryHashTable(t *testing.T) {
+	table := EntryHashTable{
+		hash:    hash(),
+		storage: make(map[uint32][]*Entry),
+	}
+	var p IEntryHashTable = &table
+
+	var wg sync.WaitGroup
+	fn := func(start, end int64) {
+		for i := start; i < end; i++ {
+			p.emplace(&Entry{name: strconv.FormatInt(i, 10)})
+		}
+		wg.Done()
+	}
+
+	wg.Add(3)
+	go fn(7, 10)
+	go fn(5, 10)
+	go fn(0, 10)
+	wg.Wait()
+
+	if len(table.storage) != 10 {
+		t.Errorf(`0: Expected len %d got %d`, 10, len(table.storage))
+	}
+
+	entries := p.get("3")
+	if len(entries) != 1 {
+		t.Errorf(`1: Expected len %d got %d`, 1, len(entries))
+	}
+	for _, e := range entries {
+		if e.name != "3" {
+			t.Errorf(`1: Expected %s got %s`, "3", e.name)
+		}
+	}
+
+	entries = p.get("5")
+	if len(entries) != 2 {
+		t.Errorf(`2: Expected len %d got %d`, 2, len(entries))
+	}
+	for _, e := range entries {
+		if e.name != "5" {
+			t.Errorf(`2: Expected %s got %s`, "5", e.name)
+		}
+	}
+
+	entries = p.get("9")
+	if len(entries) != 3 {
+		t.Errorf(`3: Expected len %d got %d`, 3, len(entries))
+	}
+	for _, e := range entries {
+		if e.name != "9" {
+			t.Errorf(`3: Expected %s got %s`, "9", e.name)
+		}
+	}
+}
+
+func TestEntryLinkedList(t *testing.T) {
+	list := &EntryLinkedList{}
+	var p IEntryLinkedList = list
+	var wg sync.WaitGroup
+	fn := func(start, end int64) {
+		for i := start; i < end; i++ {
+			p.append(&Entry{name: strconv.FormatInt(i, 10)})
+		}
+		wg.Done()
+	}
+	wg.Add(3)
+	go fn(6, 10)
+	go fn(0, 3)
+	go fn(3, 6)
+	wg.Wait()
+
+	if p.len() != 10 {
+		t.Errorf(`0: Expect %d got %d`, 10, p.len())
+	}
+	expected := []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	iter := list.begin()
+	var count int = 0
+	for ; iter != nil; count++ {
+		val, _ := strconv.ParseInt(iter.value(), 10, 64)
+		if ok := slices.Contains(expected, val); !ok {
+			t.Errorf(`1: Value %d is not contained in %v`,
+				val,
+				expected[count])
+		}
+		iter = iter.next
+	}
+	if count != 10 {
+		t.Errorf(`0: Expect %d got %d`, 10, count)
+	}
+}


### PR DESCRIPTION
- fzf delegate will handle input/output channel by itself.
- entry manager now allows custom loading entries (for testing).
- doing filtering before all entries are loaded may not get all desired entries.